### PR TITLE
Moved from using nalgebra to using alga

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,15 @@ keywords = [ "distribution", "poisson-disk", "multidimensional", "sampling" ]
 license = "MIT"
 
 [dependencies]
-rand = "0.3.8"
-nalgebra = "0.2.18"
-num = "0.1.25"
-lazy_static = "0.1.11"
-modulo = "0.1.0"
-sphere = "0.2.0"
+rand = "0.3"
+alga = "0.5"
+num-traits = "0.1"
+lazy_static = "0.1"
+modulo = "0.1"
+sphere = "0.2"
+
+[dev-dependencies]
+nalgebra = "0.11"
 
 [profile.test]
 opt-level = 3

--- a/src/algorithm/ebeida.rs
+++ b/src/algorithm/ebeida.rs
@@ -15,12 +15,13 @@ pub struct Ebeida;
 
 impl<F, V> Creator<F, V> for Ebeida
     where F: Float,
-          V: Vector<F>
+          V: Vector<F>,
+
 {
     type Algo = Algo<F, V>;
 
     fn create(poisson: &Builder<F, V>) -> Self::Algo {
-        let dim = V::dim(None);
+        let dim = V::dimension();
         let grid = Grid::new(poisson.radius, poisson.poisson_type);
         let mut indices = Vec::with_capacity(grid.cells() * dim);
         let choices = (0..grid.side()).collect::<Vec<_>>();
@@ -53,7 +54,8 @@ impl<F, V> Creator<F, V> for Ebeida
 
 pub struct Algo<F, V>
     where F: Float,
-          V: Vector<F>
+          V: Vector<F>,
+
 {
     grid: Grid<F, V>,
     indices: Vec<V>,
@@ -68,7 +70,8 @@ pub struct Algo<F, V>
 
 impl<F, V> Algorithm<F, V> for Algo<F, V>
     where F: Float,
-          V: Vector<F>
+          V: Vector<F>,
+
 {
     fn next<R>(&mut self, poisson: &mut Builder<F, V>, rng: &mut R) -> Option<V>
         where R: Rng
@@ -139,7 +142,7 @@ impl<F, V> Algorithm<F, V> for Algo<F, V>
     fn size_hint(&self, poisson: &Builder<F, V>) -> (usize, Option<usize>) {
         // Calculating lower bound should work because we calculate how much volume is left to be filled at worst case and
         // how much sphere can fill it at best case and just figure out how many fills are still needed.
-        let dim = V::dim(None);
+        let dim = V::dimension();
         let side = 2usize.pow(self.level as u32);
         let spacing = self.grid.cell() / F::cast(side);
         let grid_volume = F::cast(self.indices.len()) * spacing.powi(dim as i32);
@@ -175,7 +178,8 @@ impl<F, V> Algorithm<F, V> for Algo<F, V>
 
 impl<F, V> Algo<F, V>
     where F: Float,
-          V: Vector<F>
+          V: Vector<F>,
+
 {
     fn subdivide(&mut self, poisson: &Builder<F, V>) {
         let choices = &[0, 1];
@@ -195,7 +199,8 @@ fn covered<F, V>(grid: &Grid<F, V>,
                  level: usize)
                  -> bool
     where F: Float,
-          V: Vector<F>
+          V: Vector<F>,
+
 {
     // TODO: This does 4^d checking of points even though it could be done 3^d
     let side = 2usize.pow(level as u32);

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -16,6 +16,7 @@ mod ebeida;
 pub trait Creator<F, V>: Copy + Debug
     where F: Float,
           V: Vector<F>,
+
 {
     type Algo: Algorithm<F, V>;
 
@@ -27,6 +28,7 @@ pub trait Creator<F, V>: Copy + Debug
 pub trait Algorithm<F, V>
     where F: Float,
           V: Vector<F>,
+
 {
     /// Advances algorithm based on Builder and Rng.
     fn next<R>(&mut self, &mut Builder<F, V>, &mut R) -> Option<V> where R: Rng;

--- a/src/utils/math.rs
+++ b/src/utils/math.rs
@@ -1,8 +1,6 @@
 use {Type, Vector, Float};
 
-use num::NumCast;
-
-use na::Dim;
+use num_traits::NumCast;
 
 // const TAU: f64
 //     = 6.283185307179586476925286766559005768394338798750211641949;
@@ -76,14 +74,15 @@ fn newton(samples: usize, dim: usize) -> usize {
 /// For non-perioditic this is supported only for 2, 3 and 4 dimensional generation.
 pub fn calc_radius<F, V>(samples: usize, relative: F, poisson_type: Type) -> F
     where F: Float,
-          V: Vector<F>
+          V: Vector<F>,
+
 {
     use Type::*;
-    assert!(Type::Perioditic == poisson_type || V::dim(None) < 5);
+    assert!(Type::Perioditic == poisson_type || V::dimension() < 5);
     assert!(samples > 0);
     assert!(relative >= F::cast(0));
     assert!(relative <= F::cast(1));
-    let dim = V::dim(None);
+    let dim = V::dimension();
     let samples = match poisson_type {
         Perioditic => samples,
         Normal => newton(samples, dim),

--- a/tests/adding.rs
+++ b/tests/adding.rs
@@ -7,10 +7,9 @@ use rand::{SeedableRng, XorShiftRng};
 extern crate sphere;
 
 extern crate nalgebra as na;
-use na::Iterable;
-pub type Vect = na::Vec2<f64>;
+pub type Vect = na::Vector2<f64>;
 
-extern crate num;
+extern crate num_traits;
 
 use std::iter::repeat;
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -4,7 +4,7 @@ use poisson::{Type, Builder};
 extern crate rand;
 
 extern crate nalgebra as na;
-use na::Vec2 as naVec2;
+use na::Vector2 as naVec2;
 pub type Vec2 = naVec2<f64>;
 
 #[test]

--- a/tests/dim2.rs
+++ b/tests/dim2.rs
@@ -8,7 +8,7 @@ use rand::{XorShiftRng, SeedableRng};
 extern crate sphere;
 
 extern crate nalgebra as na;
-pub type Vect = na::Vec2<f64>;
+pub type Vect = na::Vector2<f64>;
 
 mod helper;
 use helper::test_with_samples;

--- a/tests/dim3.rs
+++ b/tests/dim3.rs
@@ -6,7 +6,7 @@ extern crate rand;
 extern crate sphere;
 
 extern crate nalgebra as na;
-pub type Vect = na::Vec3<f64>;
+pub type Vect = na::Vector3<f64>;
 
 mod helper;
 use helper::test_with_samples;

--- a/tests/dim4.rs
+++ b/tests/dim4.rs
@@ -6,7 +6,7 @@ extern crate rand;
 extern crate sphere;
 
 extern crate nalgebra as na;
-pub type Vect = na::Vec4<f64>;
+pub type Vect = na::Vector4<f64>;
 
 mod helper;
 use helper::test_with_samples;

--- a/tests/helper/mod.rs
+++ b/tests/helper/mod.rs
@@ -3,19 +3,21 @@ use poisson::{Type, Builder, Vector, Float, algorithm};
 
 use rand::{SeedableRng, XorShiftRng};
 
-extern crate num;
-use self::num::NumCast;
+extern crate num_traits;
+use self::num_traits::NumCast;
 
-use na::Norm;
+extern crate alga;
+use self::alga::general::AbstractField;
+use self::alga::linear::{NormedSpace, FiniteDimVectorSpace};
 
 use std::fmt::Debug;
 
 pub fn print_v<F: Float, V: Vector<F>>(v: V) -> String {
     let mut result = "(".to_owned();
-    for i in v.iter() {
-        result.push_str(&format!("{}, ", i.to_f64().unwrap()));
+    for i in 0..V::dimension() {
+        result.push_str(&format!("{}, ", v[i].to_f64().unwrap()));
     }
-    if V::dim(None) != 0 {
+    if V::dimension() != 0 {
         result.pop();
     }
     result.push(')');
@@ -89,7 +91,7 @@ pub fn test_poisson<F, I, T, A>(poisson: I, radius: F, poisson_type: Type, algo:
     where I: Iterator<Item=T>, F: Float, T: Debug + Vector<F> + Copy, A: algorithm::Creator<F, T>
 {
     use poisson::Type::*;
-    let dim = T::dim(None);
+    let dim = T::dimension();
     let mut vecs = vec![];
     let mut hints = vec![];
     {
@@ -116,10 +118,10 @@ pub fn test_poisson<F, I, T, A>(poisson: I, radius: F, poisson_type: Type, algo:
             for n in 0..3i64.pow(dim as u32) {
                 let mut t = T::zero();
                 let mut div = n;
-                for i in t.iter_mut() {
+                for i in 0..T::dimension() {
                     let rem = div % 3;
                     div /= 3;
-                    *i = NumCast::from(rem - 1).unwrap();
+                    t[i] = NumCast::from(rem - 1).unwrap();
                 }
                 for v in &vecs {
                     vecs2.push(*v + t);

--- a/tests/validity.rs
+++ b/tests/validity.rs
@@ -8,11 +8,13 @@ use rand::distributions::normal::StandardNormal;
 extern crate sphere;
 
 extern crate nalgebra as na;
-use na::{Norm, IterableMut};
-pub type Vect = na::Vec2<f64>;
+pub type Vect = na::Vector2<f64>;
 
-extern crate num;
-use num::Zero;
+extern crate alga;
+use self::alga::linear::FiniteDimVectorSpace;
+
+extern crate num_traits;
+use num_traits::Zero;
 
 use helper::When::*;
 
@@ -44,8 +46,8 @@ fn multiple_too_close_invalid() {
 
 pub fn sphere_uniform_point<R: Rng>(rng: &mut R) -> Vect {
     let mut result = Vect::zero();
-    for c in result.iter_mut() {
-        *c = StandardNormal::rand(rng).0;
+    for c in 0..Vect::dimension() {
+        result[c] = StandardNormal::rand(rng).0;
     }
     result.normalize()
 }


### PR DESCRIPTION
This PR moves the library from using `nalgebra` directly to using `alga` which new versions of `nalgebra` use. 

The library can now be used with any library that provides vectors and works with `alga`.