### PR TITLE
minimal nalgebra@0.14 upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = [ "distribution", "poisson-disk", "multidimensional", "sampling" ]
 license = "MIT"
 
 [dependencies]
-rand = "0.3"
+rand = "0.4"
 alga = "0.5"
 num-traits = "0.1"
 lazy_static = "0.1"
@@ -18,7 +18,7 @@ modulo = "0.1"
 sphere = "0.2"
 
 [dev-dependencies]
-nalgebra = "0.11"
+nalgebra = "0.14"
 
 [profile.test]
 opt-level = 3

--- a/tests/dim2.rs
+++ b/tests/dim2.rs
@@ -18,12 +18,12 @@ fn test_one_sample_works() {
     let rand = XorShiftRng::from_seed([1, 2, 3, 4]);
     let builder = Builder::<_, Vect>::with_samples(1, 0.8, Normal);
     let builder = builder.build(rand, algorithm::Ebeida);
-    builder.into_iter().collect::<Vec<Vect>>();
+    builder.into_iter().for_each(drop);
 
     let rand = XorShiftRng::from_seed([1, 2, 3, 4]);
     let builder = Builder::<_, Vect>::with_samples(1, 0.8, Normal);
     let builder = builder.build(rand, algorithm::Bridson);
-    builder.into_iter().collect::<Vec<Vect>>();
+    builder.into_iter().for_each(drop);
 }
 
 #[test]


### PR DESCRIPTION
... to avoid breaking with rust-lang/rust#49799.

nalgebra 0.15 uses rand 0.5 which brings in a lot of changes around `Rand`. I'm not familiar with poisson enough to port it further along.