### PR TITLE
Dependency update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,15 @@ keywords = [ "distribution", "poisson-disk", "multidimensional", "sampling" ]
 license = "MIT"
 
 [dependencies]
-rand = "0.5"
-alga = "0.7"
+rand = "0.6"
+alga = "0.8"
 num-traits = "0.2"
-lazy_static = "0.1"
+lazy_static = "1.3"
 modulo = "0.1"
 sphere = "0.3"
 
 [dev-dependencies]
-nalgebra = "0.16"
+nalgebra = "0.17"
 
 [profile.test]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ sphere = "0.3"
 
 [dev-dependencies]
 nalgebra = "0.17"
+rand_xorshift = "0.1.1"
 
 [profile.test]
 opt-level = 3

--- a/tests/adding.rs
+++ b/tests/adding.rs
@@ -2,7 +2,10 @@ extern crate poisson;
 use poisson::{Type, Builder, algorithm};
 
 extern crate rand;
-use rand::{SeedableRng, XorShiftRng};
+use rand::SeedableRng;
+
+extern crate rand_xorshift;
+use rand_xorshift::XorShiftRng;
 
 extern crate sphere;
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -2,6 +2,7 @@ extern crate poisson;
 use poisson::{Type, Builder};
 
 extern crate rand;
+extern crate rand_xorshift;
 
 extern crate nalgebra as na;
 use na::Vector2 as naVec2;

--- a/tests/dim2.rs
+++ b/tests/dim2.rs
@@ -1,9 +1,12 @@
 extern crate poisson;
-use poisson::{Builder, algorithm};
 use poisson::Type::*;
+use poisson::{algorithm, Builder};
 
 extern crate rand;
-use rand::{XorShiftRng, SeedableRng};
+use rand::SeedableRng;
+
+extern crate rand_xorshift;
+use rand_xorshift::XorShiftRng;
 
 extern crate sphere;
 

--- a/tests/dim3.rs
+++ b/tests/dim3.rs
@@ -2,6 +2,7 @@ extern crate poisson;
 use poisson::Type::*;
 
 extern crate rand;
+extern crate rand_xorshift;
 
 extern crate sphere;
 

--- a/tests/dim4.rs
+++ b/tests/dim4.rs
@@ -2,6 +2,7 @@ extern crate poisson;
 use poisson::Type::*;
 
 extern crate rand;
+extern crate rand_xorshift;
 
 extern crate sphere;
 

--- a/tests/helper/mod.rs
+++ b/tests/helper/mod.rs
@@ -1,8 +1,10 @@
 #![allow(unused)]
 use poisson::{Type, Builder, Vector, Float, algorithm};
 
-use rand::{SeedableRng, XorShiftRng};
+use rand::SeedableRng;
 use rand::distributions::{Distribution, Standard};
+
+use rand_xorshift::XorShiftRng;
 
 extern crate num_traits;
 use self::num_traits::NumCast;

--- a/tests/validity.rs
+++ b/tests/validity.rs
@@ -3,7 +3,7 @@ use poisson::Type;
 
 extern crate rand;
 use rand::{Rng, SeedableRng, XorShiftRng};
-use rand::distributions::normal::StandardNormal;
+use rand::distributions::StandardNormal;
 
 extern crate sphere;
 

--- a/tests/validity.rs
+++ b/tests/validity.rs
@@ -2,8 +2,11 @@ extern crate poisson;
 use poisson::Type;
 
 extern crate rand;
-use rand::{Rng, SeedableRng, XorShiftRng};
+use rand::{Rng, SeedableRng};
 use rand::distributions::StandardNormal;
+
+extern crate rand_xorshift;
+use rand_xorshift::XorShiftRng;
 
 extern crate sphere;
 


### PR DESCRIPTION
I updated the dependencies because the older dependencies did not mix well with my code. The tests also now use `XorShiftRng` from the crate `rand_xorshift`, as it was moved from `rand` into a separate crate.