### PR TITLE
Fixes assert failure in Bridson

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 This is a library for generating n-dimensional [poisson-disk distributions](http://mollyrocket.com/casey/stream_0014.html).    
 
-It generates distribution of points in [0, 1]<sup>d</sup> where:
+It generates distribution of points in [0, 1)<sup>d</sup> where:
 
  * For each point there is disk of certain radius which doesn't intersect
  with any other disk of other points

--- a/poisson/src/algorithm/bridson.rs
+++ b/poisson/src/algorithm/bridson.rs
@@ -65,7 +65,7 @@ where
                 let sample = cur.clone() + random_point_annulus(rng, min, max);
                 if (0..V::dimension())
                     .map(|n| sample[n])
-                    .all(|c| F::cast(0) <= c && c <= F::cast(1))
+                    .all(|c| F::cast(0) <= c && c < F::cast(1))
                 {
                     let index = sample_to_index(&sample, self.grid.side());
                     if self.insert_if_valid(poisson, index, sample.clone()) {
@@ -146,7 +146,7 @@ where
             self.active_samples.push(sample.clone());
             self.grid
                 .get_mut(index)
-                .expect("Because the sample is [0, 1] indexing it should work.")
+                .expect("Because the sample is [0, 1) indexing it should work.")
                 .push(sample);
             self.success += 1;
             true

--- a/poisson/src/lib.rs
+++ b/poisson/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Poisson-disk distribution generation
 //!
-//! Generates distribution of points in [0, 1]<sup>d</sup> where:
+//! Generates distribution of points in [0, 1)<sup>d</sup> where:
 //!
 //! * For each point there is disk of certain radius which doesn't intersect
 //! with any other disk of other points
@@ -13,7 +13,7 @@
 //!
 //! # Examples
 //!
-//! Generate non-tiling poisson-disk distribution in [0, 1]<sup>2</sup> with disk radius 0.1
+//! Generate non-tiling poisson-disk distribution in [0, 1)<sup>2</sup> with disk radius 0.1
 //! using slower but more accurate algorithm.
 //!
 //! ````rust
@@ -35,7 +35,7 @@
 //! }
 //! ````
 //!
-//! Generate tiling poisson-disk distribution in [0, 1]<sup>3</sup> with approximately 100 samples
+//! Generate tiling poisson-disk distribution in [0, 1)<sup>3</sup> with approximately 100 samples
 //! and relative disk radius 0.9 using faster but less accurate algorithm.
 //!
 //! ````rust
@@ -104,7 +104,7 @@ where
         + NormedSpace<Field = F>
         + Index<usize>
         + IndexMut<usize>
-        + Clone,
+        + Clone
 {
 }
 

--- a/poisson/tests/helper/mod.rs
+++ b/poisson/tests/helper/mod.rs
@@ -122,8 +122,10 @@ fn test_algo<'r, T, F, I, A>(
         let mut poisson = vec![];
         let mut prefill = (prefiller)(poisson_iter.radius());
         let mut last = None;
+        let mut does_prefill = false;
         loop {
             while let Some(p) = (prefill)(last) {
+                does_prefill = true;
                 match valid {
                     Always => assert!(
                         poisson_iter.stays_legal(p),
@@ -162,11 +164,11 @@ fn test_algo<'r, T, F, I, A>(
             }
             .into_iter(),
         );
-        test_poisson(poisson, radius, poisson_type, algo);
+        test_poisson(poisson, radius, poisson_type, algo, does_prefill);
     }
 }
 
-pub fn test_poisson<F, I, T, A>(poisson: I, radius: F, poisson_type: Type, algo: A)
+pub fn test_poisson<F, I, T, A>(poisson: I, radius: F, poisson_type: Type, algo: A, does_prefill: bool)
 where
     I: Iterator<Item = T>,
     F: Float,
@@ -197,6 +199,15 @@ where
         let remaining = len - (n + 1);
         assert!(l <= remaining, "For the '{:?}' algorithm the lower bound of hint should be smaller than or equal to actual: {} <= {}", algo, l, remaining);
         assert!(h >= remaining, "For the '{:?}' algorithm the upper bound of hint should be larger than or equal to actual: {} >= {}", algo, h, remaining);
+    }
+
+    if !does_prefill {
+        for v in &vecs {
+            for n in 0..T::dimension() {
+                assert!(v[n] >= F::cast(0));
+                assert!(v[n] < F::cast(1));
+            }
+        }
     }
 
     let vecs = match poisson_type {

--- a/poisson/tests/reproductions.rs
+++ b/poisson/tests/reproductions.rs
@@ -1,0 +1,14 @@
+extern crate nalgebra as na;
+
+use rand::{rngs::SmallRng, SeedableRng};
+
+use poisson::{Builder, Type, algorithm};
+
+#[test]
+fn reproduce_issue_29() {
+    let seed = [160, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    let rng = SmallRng::from_seed(seed);
+    Builder::<_, na::Vector2<f32>>::with_radius(0.004, Type::Normal)
+        .build(rng, algorithm::Bridson)
+        .generate();
+}


### PR DESCRIPTION
Fixes #29 

This was caused by samples generated with at least one coordinate being 1.
I changed it to generate points [0,1) which actually is what Ebeida was already doing looking at the code now.
This is also more usable as these tiles fit neatly next to each other and random generation is almost always exclusive on the upper bound.